### PR TITLE
Support tags other than div

### DIFF
--- a/src/GridColumn.js
+++ b/src/GridColumn.js
@@ -27,6 +27,12 @@ class GridColumn extends React.Component {
       styles, tagName, className, children,
     } = this.props;
 
+    if (styles) {
+      if (console && console.warn) {
+        console.warn("The `styles` prop is deprecated and will be removed in the future. Use the standard `style` prop instead.");
+      }
+    }
+
     const classes = classnames({
       [flexboxgrid["col-xs"]]: xs && xs === "auto",
       [flexboxgrid["col-sm"]]: sm && sm === "auto",
@@ -53,7 +59,7 @@ class GridColumn extends React.Component {
     return (
       <Element {...this.props}
                className={classes}
-               style={styles}>
+               style={this.props.style || styles}>
         {children}
       </Element>
     );

--- a/src/GridColumn.js
+++ b/src/GridColumn.js
@@ -13,76 +13,49 @@ class GridColumn extends React.Component {
     mdOffset: PropTypes.number,
     lgOffset: PropTypes.number,
     styles: PropTypes.object,
+    tagName: PropTypes.string,
+  };
+
+  static defaultProps = {
+    tagName: "div",
   };
 
   render() {
-    let extraSmallClass = "";
-    let smallClass = "";
-    let mediumClass = "";
-    let largeClass = "";
-    let extraSmallOffsetClass = "";
-    let smallOffsetClass = "";
-    let mediumOffsetClass = "";
-    let largeOffsetClass = "";
+    const {
+      xs, sm, md, lg,
+      xsOffset, smOffset, mdOffset, lgOffset,
+      styles, tagName, className, children,
+    } = this.props;
 
-    const styles = this.props.styles;
+    const classes = classnames({
+      [flexboxgrid["col-xs"]]: xs && xs === "auto",
+      [flexboxgrid["col-sm"]]: sm && sm === "auto",
+      [flexboxgrid["col-md"]]: md && md === "auto",
+      [flexboxgrid["col-lg"]]: lg && lg === "auto",
 
-    if (this.props.xs) {
-      if (this.props.xs === "auto") {
-        extraSmallClass = flexboxgrid[`col-xs`];
-      } else {
-        extraSmallClass = flexboxgrid[`col-xs-${this.props.xs}`];
-      }
-    }
-    if (this.props.sm) {
-      if (this.props.sm === "auto") {
-        smallClass = flexboxgrid[`col-sm`];
-      } else {
-        smallClass = flexboxgrid[`col-sm-${this.props.sm}`];
-      }
-    }
-    if (this.props.md) {
-      if (this.props.md === "auto") {
-        mediumClass = flexboxgrid[`col-md`];
-      } else {
-        mediumClass = flexboxgrid[`col-md-${this.props.md}`];
-      }
-    }
-    if (this.props.lg) {
-      if (this.props.lg === "auto") {
-        largeClass = flexboxgrid[`col-lg`];
-      } else {
-        largeClass = flexboxgrid[`col-lg-${this.props.lg}`];
-      }
-    }
+      [flexboxgrid[`col-xs-${xs}`]]: xs && xs !== "auto",
+      [flexboxgrid[`col-sm-${sm}`]]: sm && sm !== "auto",
+      [flexboxgrid[`col-md-${md}`]]: md && md !== "auto",
+      [flexboxgrid[`col-lg-${lg}`]]: lg && lg !== "auto",
 
-    if (this.props.xsOffset) {
-      extraSmallOffsetClass = flexboxgrid[`col-xs-offset-${this.props.xsOffset}`];
-    }
-    if (this.props.smOffset) {
-      smallOffsetClass = flexboxgrid[`col-sm-offset-${this.props.smOffset}`];
-    }
-    if (this.props.mdOffset) {
-      mediumOffsetClass = flexboxgrid[`col-md-offset-${this.props.mdOffset}`];
-    }
-    if (this.props.lgOffset) {
-      largeOffsetClass = flexboxgrid[`col-lg-offset-${this.props.lgOffset}`];
-    }
+      [flexboxgrid[`col-xs-offset-${xsOffset}`]]: xsOffset,
+      [flexboxgrid[`col-sm-offset-${smOffset}`]]: smOffset,
+      [flexboxgrid[`col-md-offset-${mdOffset}`]]: mdOffset,
+      [flexboxgrid[`col-lg-offset-${lgOffset}`]]: lgOffset,
+
+      [className]: true,
+    });
+
+    // The name of the variable has to start with an uppercase otherwise JSX
+    // would literally create `<element>`.
+    const Element = tagName;
 
     return (
-      <div className={classnames(
-        this.props.className,
-        extraSmallClass,
-        extraSmallOffsetClass,
-        smallClass,
-        smallOffsetClass,
-        mediumClass,
-        mediumOffsetClass,
-        largeClass,
-        largeOffsetClass)}
-        style={styles}>
-        {this.props.children}
-      </div>
+      <Element {...this.props}
+               className={classes}
+               style={styles}>
+        {children}
+      </Element>
     );
   }
 }

--- a/src/GridRow.js
+++ b/src/GridRow.js
@@ -1,93 +1,60 @@
-import React from "react";
+import React, { PropTypes } from "react";
 import classnames from "classnames";
 import flexboxgrid from "flexboxgrid/dist/flexboxgrid.css";
 
 class GridRow extends React.Component {
   static propTypes = {
-    reverse: React.PropTypes.bool,
-    xsAlign: React.PropTypes.string,
-    smAlign: React.PropTypes.string,
-    mdAlign: React.PropTypes.string,
-    lgAlign: React.PropTypes.string,
-    xsVAlign: React.PropTypes.string,
-    smVAlign: React.PropTypes.string,
-    mdVAlign: React.PropTypes.string,
-    lgVAlign: React.PropTypes.string,
-    styles: React.PropTypes.object,
+    reverse: PropTypes.bool,
+    xsAlign: PropTypes.string,
+    smAlign: PropTypes.string,
+    mdAlign: PropTypes.string,
+    lgAlign: PropTypes.string,
+    xsVAlign: PropTypes.string,
+    smVAlign: PropTypes.string,
+    mdVAlign: PropTypes.string,
+    lgVAlign: PropTypes.string,
+    styles: PropTypes.object,
+    tagName: PropTypes.string,
   };
 
   static defaultProps = {
-    reverse: false,
-    xsAlign: null,
-    smAlign: null,
-    mdAlign: null,
-    lgAlign: null,
-    xsVAlign: null,
-    smVAlign: null,
-    mdVAlign: null,
-    lgVAlign: null,
-    styles: {},
+    tagName: "div",
   };
 
   render() {
-    let reverseClass = "";
-    let xsAlignClass = "";
-    let smAlignClass = "";
-    let mdAlignClass = "";
-    let lgAlignClass = "";
-    let xsVAlignClass = "";
-    let smVAlignClass = "";
-    let mdVAlignClass = "";
-    let lgVAlignClass = "";
+    const {
+      reverse,
+      xsAlign, smAlign, mdAlign, lgAlign,
+      xsVAlign, smVAlign, mdVAlign, lgVAlign,
+      styles, tagName, className, children,
+    } = this.props;
 
-    const styles = this.props.styles;
+    const classes = classnames({
+      [flexboxgrid.reverse]: reverse,
 
-    if (this.props.reverse) {
-      reverseClass = flexboxgrid.reverse;
-    }
+      [flexboxgrid[`${this.props.xsAlign}-xs`]]: xsAlign,
+      [flexboxgrid[`${this.props.smAlign}-sm`]]: smAlign,
+      [flexboxgrid[`${this.props.mdAlign}-md`]]: mdAlign,
+      [flexboxgrid[`${this.props.lgAlign}-lg`]]: lgAlign,
 
-    if (this.props.xsAlign) {
-      xsAlignClass = flexboxgrid[`${this.props.xsAlign}-xs`];
-    }
-    if (this.props.smAlign) {
-      smAlignClass = flexboxgrid[`${this.props.smAlign}-sm`];
-    }
-    if (this.props.mdAlign) {
-      mdAlignClass = flexboxgrid[`${this.props.mdAlign}-md`];
-    }
-    if (this.props.lgAlign) {
-      lgAlignClass = flexboxgrid[`${this.props.lgAlign}-lg`];
-    }
+      [flexboxgrid[`${this.props.xsVAlign}-xs`]]: xsVAlign,
+      [flexboxgrid[`${this.props.smVAlign}-sm`]]: smVAlign,
+      [flexboxgrid[`${this.props.mdVAlign}-md`]]: mdVAlign,
+      [flexboxgrid[`${this.props.lgVAlign}-lg`]]: lgVAlign,
 
-    if (this.props.xsVAlign) {
-      xsVAlignClass = flexboxgrid[`${this.props.xsVAlign}-xs`];
-    }
-    if (this.props.smVAlign) {
-      smVAlignClass = flexboxgrid[`${this.props.smVAlign}-sm`];
-    }
-    if (this.props.mdVAlign) {
-      mdVAlignClass = flexboxgrid[`${this.props.mdVAlign}-md`];
-    }
-    if (this.props.lgVAlign) {
-      lgVAlignClass = flexboxgrid[`${this.props.lgVAlign}-lg`];
-    }
+      [className]: true,
+    });
+
+    // The name of the variable has to start with an uppercase otherwise JSX
+    // would literally create `<element>`.
+    const Element = tagName;
 
     return (
-      <div className={classnames(
-        this.props.className,
-        flexboxgrid.row,
-        reverseClass,
-        xsAlignClass,
-        smAlignClass,
-        mdAlignClass,
-        lgAlignClass,
-        xsVAlignClass,
-        smVAlignClass,
-        mdVAlignClass,
-        lgVAlignClass)}
-        style={styles}>
-        {this.props.children}
-      </div>
+      <Element {...this.props}
+               className={classes}
+               style={styles}>
+        {children}
+      </Element>
     );
   }
 }

--- a/src/GridRow.js
+++ b/src/GridRow.js
@@ -13,7 +13,7 @@ class GridRow extends React.Component {
     smVAlign: PropTypes.string,
     mdVAlign: PropTypes.string,
     lgVAlign: PropTypes.string,
-    styles: PropTypes.object,
+    styles: PropTypes.object, // TODO: remove this
     tagName: PropTypes.string,
   };
 
@@ -28,6 +28,12 @@ class GridRow extends React.Component {
       xsVAlign, smVAlign, mdVAlign, lgVAlign,
       styles, tagName, className, children,
     } = this.props;
+
+    if (styles) {
+      if (console && console.warn) {
+        console.warn("The `styles` prop is deprecated and will be removed in the future. Use the standard `style` prop instead.");
+      }
+    }
 
     const classes = classnames({
       [flexboxgrid.reverse]: reverse,
@@ -52,7 +58,7 @@ class GridRow extends React.Component {
     return (
       <Element {...this.props}
                className={classes}
-               style={styles}>
+               style={this.props.style || styles}>
         {children}
       </Element>
     );


### PR DESCRIPTION
- The element for `GridRow` and `GridColumn` can be specified with `tagName`. Keeping the default as `div` to maintain the same behaviour.
- All props are passed to the element to make it possible to e.g. set `key` prop.
- Spit out deprecation warnings for `styles` (recommend `style` instead)

@sricho This is not meant to make anything backwards incompatible, just adding new things.
